### PR TITLE
Transfer thumbnail images

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,10 @@ npm install --save node-red-contrib-image-output
 ### Width
 The width (in pixels) that the image needs to be displayed in the flow.  The height will be calculated automatically, with the same aspect ratio as the original image.
 
-### Transfer thumbnail images
-When activated, the input image will be resized automatically (to the specified) width.  By transferring smaller images the bandwith can be reduced, i.e. the number of bytes that is being send across the network.  When too much data is pushed (across the websocket), the flow editor can become ***unresponse***!
+### Resize images on server side
+By transferring smaller images the bandwith can be reduced, i.e. the number of bytes that is being send across the network.  When too much data is pushed (across the websocket), the flow editor can become ***unresponse***!
 
-Caution: resizing images will require server-side CPU usage.  So it has decided what is required: lower bandwidth or lower cpu usage.  This decision will depend on the use case...
++ When this option is activated, the images will be resized (to the specified width) on the server side.  Then those small thumbnail images will be send to the browser, to reduce the bandwith. 
++ When this option is not activated, the (original) large images will be send to the browser.  Once they arrive there, the browser will resize them to the specified width.  As a result much more data needs to be transferred between the server and the browser.
+        
+Caution: resizing images on the server will require server-side CPU usage.  So it has to be decided what is prefferd: lower bandwidth or lower cpu usage on the server.  This decision will depend on the use case...

--- a/README.md
+++ b/README.md
@@ -1,16 +1,24 @@
-# 🏞 node-red-contrib-image-output
+# ðŸž node-red-contrib-image-output
 
-Simple image output node. Useful for previewing results of face detecting, object recognition etc.
+Simple image output node. Useful for previewing images (of face detecting, object recognition etc...) inside the Node-RED flow editor.
 
 ![](https://raw.githubusercontent.com/rikukissa/node-red-contrib-image-output/master/.github/preview.png)
 
-Expects received `msg.payload` to contain either a buffer or a base64 string of a jpg or png image.
+Expects the `msg.payload` to contain a jpg or png image, which need to be either a buffer or a base64 string.
+
 
 ## Installation
-
-Either use Menu - Manage palette - Install in the editor, or
-
+Run the following npm command in your Node-RED user directory (typically ~/.node-red):
 ```
-cd ~/.node-red
 npm install --save node-red-contrib-image-output
 ```
+
+## Node configuration
+
+### Width
+The width (in pixels) that the image needs to be displayed in the flow.  The height will be calculated automatically, with the same aspect ratio as the original image.
+
+### Transfer thumbnail images
+When activated, the input image will be resized automatically (to the specified) width.  By transferring smaller images the bandwith can be reduced, i.e. the number of bytes that is being send across the network.  When too much data is pushed (across the websocket), the flow editor can become ***unresponse***!
+
+Caution: resizing images will require server-side CPU usage.  So it has decided what is required: lower bandwidth or lower cpu usage.  This decision will depend on the use case...

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ðŸž node-red-contrib-image-output
+# 🏞 node-red-contrib-image-output
 
 Simple image output node. Useful for previewing images (of face detecting, object recognition etc...) inside the Node-RED flow editor.
 

--- a/image/image.html
+++ b/image/image.html
@@ -30,36 +30,45 @@
       $('#node-input-width').val(this.width || DEFAULT_IMAGE_WIDTH);
     }
   });
+  
   const latestImages = {}
+
   function remove(nodeid) {
     const id = nodeid
     const $img = document.getElementById("image-output-img-"+id)
     const $bubble = document.getElementById("image-output-bubble-"+id)
+
     $img && $img.remove()
     $bubble && $bubble.remove()
     delete latestImages[id]
   }
+
   function redraw(node) {
     const id = node.id
     const $img = document.getElementById("image-output-img-"+id)
     const $bubble = document.getElementById("image-output-bubble-"+id)
+
     $img && $img.remove()
     $bubble && $bubble.remove()
+
     if (latestImages[id]) {
       render(id, latestImages[id], node)
     }
   }
+
   function render(id, data, node) {
     let i = new Image();
     let $img = document.getElementById("image-output-img-"+id)
     if (!$img) {
       const $container = document.getElementById(id)
       if (!$container) { return }
+
       const bubble = document.createElementNS("http://www.w3.org/2000/svg", 'polyline')
       bubble.setAttribute('id', "image-output-bubble-"+id)
       bubble.setAttribute('style', 'fill:#A7BBCE')
       bubble.setAttribute('stroke', '#999999')
       $container.insertBefore(bubble, $container.lastChild.nextSibling)
+
       const img = document.createElementNS("http://www.w3.org/2000/svg", 'image')
       img.setAttribute('id', "image-output-img-"+id)
       img.setAttribute('x', '0')
@@ -69,6 +78,7 @@
       $container.insertBefore(img, $container.lastChild.nextSibling)
       $img = img
     }
+
     i.onload = function () {
       $img.setAttribute('height', node.width * i.height / i.width)
       const bubbleId = $img.id.replace("img", "bubble");
@@ -91,10 +101,13 @@
         left + "," + (top - 21)
       $bubble.setAttribute('points', points)
     }
+
     $img.setAttribute('href', "data:image/png;base64,"+data)
     i.src = "data:image/png;base64,"+data;
   }
+
   RED.events.on("editor:save", redraw)
+
   RED.comms.subscribe('image', function(event, data) {
     if (data.hasOwnProperty("data")) {
         latestImages[data.id] = data.data
@@ -104,6 +117,7 @@
         remove(data.id);
     }
   })
+
 </script>
 
 <script type="text/x-red" data-template-name="image">
@@ -114,7 +128,7 @@
   <div class="form-row">
     <label>&nbsp;</label>
     <input type="checkbox" id="node-input-thumbnail" style="display: inline-block; width: auto; vertical-align: top;">
-    <label for="node-input-thumbnail" style="width:70%;"> Transfer thumbnail images (to reduce bandwidth)</label>
+    <label for="node-input-thumbnail" style="width:70%;"> Resize images on server side</label>
   </div> 
   <div class="form-row">
     <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
@@ -126,7 +140,12 @@
     <p>Simple image output node. Useful for previewing results of face detecting, object recognition etc.</p>
     <p>Expects <code>msg.payload</code> to contain either a buffer or a base64 string of a jpg or png image.</p>
     <p><strong>Width:</strong><br/>
-    The width (in pixels) that the image needs to be displayed in the flow.</p>     
-    <p><strong>Transfer thumbnail images:</strong><br/>
-    Resize the images (to the specified) width, to reduce the bandwith.  When too much data is pushed, the flow editor can become unresponse!</p> 
+    The width (in pixels) that the image needs to be displayed in the flow.</p>  
+    <p><strong>Resize images on server side:</strong><br/>
+    When too much data is pushed to the browser, the flow editor can become unresponse!
+    <ul>
+        <li>When activated, the images will be resized (to the specified width) on the server side.  Then those small thumbnail images will be send to the browser, to reduce the bandwith.</li>
+        <li>When not activated, the (original) large images will be send to the browser.  Once they arrive there, the browser will resize them to the specified width.</li>
+    </ul>
+    </p> 
 </script>

--- a/image/image.html
+++ b/image/image.html
@@ -10,6 +10,9 @@
         required: true,
         validate: function(v) { return !v || !isNaN(parseInt(v, 10)) }
       },
+      thumbnail: {
+        value: false
+      }
     },
     inputs: 1,
     outputs: 0,
@@ -27,45 +30,36 @@
       $('#node-input-width').val(this.width || DEFAULT_IMAGE_WIDTH);
     }
   });
-
   const latestImages = {}
-
   function remove(nodeid) {
     const id = nodeid
     const $img = document.getElementById("image-output-img-"+id)
     const $bubble = document.getElementById("image-output-bubble-"+id)
-
     $img && $img.remove()
     $bubble && $bubble.remove()
     delete latestImages[id]
   }
-
   function redraw(node) {
     const id = node.id
     const $img = document.getElementById("image-output-img-"+id)
     const $bubble = document.getElementById("image-output-bubble-"+id)
-
     $img && $img.remove()
     $bubble && $bubble.remove()
-
     if (latestImages[id]) {
       render(id, latestImages[id], node)
     }
   }
-
   function render(id, data, node) {
     let i = new Image();
     let $img = document.getElementById("image-output-img-"+id)
     if (!$img) {
       const $container = document.getElementById(id)
       if (!$container) { return }
-
       const bubble = document.createElementNS("http://www.w3.org/2000/svg", 'polyline')
       bubble.setAttribute('id', "image-output-bubble-"+id)
       bubble.setAttribute('style', 'fill:#A7BBCE')
       bubble.setAttribute('stroke', '#999999')
       $container.insertBefore(bubble, $container.lastChild.nextSibling)
-
       const img = document.createElementNS("http://www.w3.org/2000/svg", 'image')
       img.setAttribute('id', "image-output-img-"+id)
       img.setAttribute('x', '0')
@@ -75,7 +69,6 @@
       $container.insertBefore(img, $container.lastChild.nextSibling)
       $img = img
     }
-
     i.onload = function () {
       $img.setAttribute('height', node.width * i.height / i.width)
       const bubbleId = $img.id.replace("img", "bubble");
@@ -98,13 +91,10 @@
         left + "," + (top - 21)
       $bubble.setAttribute('points', points)
     }
-
     $img.setAttribute('href', "data:image/png;base64,"+data)
     i.src = "data:image/png;base64,"+data;
   }
-
   RED.events.on("editor:save", redraw)
-
   RED.comms.subscribe('image', function(event, data) {
     if (data.hasOwnProperty("data")) {
         latestImages[data.id] = data.data
@@ -114,7 +104,6 @@
         remove(data.id);
     }
   })
-
 </script>
 
 <script type="text/x-red" data-template-name="image">
@@ -122,6 +111,11 @@
     <label for="node-input-width"><i class="fa fa-arrows-h"></i> Width</label>
     <input type="number" id="node-input-width">
   </div>
+  <div class="form-row">
+    <label>&nbsp;</label>
+    <input type="checkbox" id="node-input-thumbnail" style="display: inline-block; width: auto; vertical-align: top;">
+    <label for="node-input-thumbnail" style="width:70%;"> Transfer thumbnail images (to reduce bandwidth)</label>
+  </div> 
   <div class="form-row">
     <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
     <input type="text" id="node-input-name" placeholder="Name">
@@ -131,4 +125,8 @@
 <script type="text/x-red" data-help-name="image">
     <p>Simple image output node. Useful for previewing results of face detecting, object recognition etc.</p>
     <p>Expects <code>msg.payload</code> to contain either a buffer or a base64 string of a jpg or png image.</p>
+    <p><strong>Width:</strong><br/>
+    The width (in pixels) that the image needs to be displayed in the flow.</p>     
+    <p><strong>Transfer thumbnail images:</strong><br/>
+    Resize the images (to the specified) width, to reduce the bandwith.  When too much data is pushed, the flow editor can become unresponse!</p> 
 </script>

--- a/image/image.js
+++ b/image/image.js
@@ -1,16 +1,67 @@
 module.exports = function(RED) {
+    var Jimp = require('jimp'); 
+    
     function ImageNode(config) {
         RED.nodes.createNode(this, config);
+        this.imageWidth = config.width;
+        this.thumbnail = config.thumbnail;
+        
         var node = this;
-
-        node.on("input", function(msg) {
+        
+        function sendImageToClient(image, msg) {
+            if (Buffer.isBuffer(image)) {
+                image = image.toString("base64");
+            }
+                
             try {
-                var data = msg.payload.toString("base64")
-                RED.comms.publish("image", { id:this.id, data:data });
-                if (msg.hasOwnProperty("filename")) { node.status({text:" "+msg.filename}); }
+                RED.comms.publish("image", { id:node.id, data:image });
+                if (msg.hasOwnProperty("filename")) { node.status({text:" " + msg.filename}); }
             }
             catch(e) {
-                node.error("Invalid image",msg);
+                node.error("Invalid image", msg);
+            }
+        } 
+
+        node.on("input", function(msg) {
+            var image = msg.payload;
+            
+            if (!Buffer.isBuffer(image) && (typeof image !== 'string') && !(image instanceof String)) {
+                node.error("Input should be a buffer or a base64 string (containing a jpg or png image)");
+                return;
+            }
+            
+            if (node.thumbnail) {
+                if (!Buffer.isBuffer(image)) {
+                    // Convert the base64 string to a buffer, so Jimp can process it
+                    image = new Buffer(image, 'base64');
+                }
+                
+                Jimp.read(image).then(function(img) {
+                    // Resize the width as specified in the config screen, and scale the height accordingly (preserving aspect ratio)
+                    img.resize(250, Jimp.AUTO);
+                    
+                    // Convert the resized image to a base64 string
+                    img.getBase64(Jimp.AUTO, (err, base64) => {
+                        if (err) {
+                            // Log the error and keep the original image (at its original size)
+                            console.error(err);
+                            sendImageToClient(image, msg);
+                        }
+                        else {
+                            // Keep the base64 image from the data url
+                            base64 = base64.replace(/^data:image\/png;base64,/, "");
+                            
+                            sendImageToClient(base64, msg);
+                        }
+                    })
+                }).catch(function(err) {
+                    // Log the error and keep the original image (at its original size)
+                    console.error(err);
+                    sendImageToClient(image, msg);
+                });
+            }
+            else {    
+                sendImageToClient(image, msg);
             }
         });
 

--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
+  
 {
   "name": "node-red-contrib-image-output",
-  "version": "0.4.3",
+  "version": "0.5.0",
   "description": "Easy way of previewing and examining images in your flows",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "jimp": "0.9.3"
   },
   "bugs": {
     "url": "https://github.com/rikukissa/node-red-contrib-image-output/issues"


### PR DESCRIPTION
Hi Riku (@rikukissa) and Dave (@dceejay),

This node is still one of my favorite nodes.  But a disadvantage is that the images are pushed via the Node-RED websocket channel, which starts choking very easily when too much data is being pushed through it.  And then my flow editor becomes _unresponsive_.

And since the images will be showed very small inside the flow editor, it has not much use to push the large (original) image through the websocket channel.  Indeed they will be resized by the browser anyway, to show it as a small thumbnail image...

To workaround this, I have added a new checkbox to the config screen:

![image](https://user-images.githubusercontent.com/14224149/70868756-1c599b00-1f84-11ea-9804-1796f4e90a96.png)

This option is deactivated by default (to keep the original behaviour).  But **_when it is activated, the image will be rescaled at server side._**  I use the width specified on the config screen, and the height is automatically calculated (to keep the same aspect ratio as the original image).

Example input base64 image:

![image](https://user-images.githubusercontent.com/14224149/70868595-8113f600-1f82-11ea-8351-42578e9b3b35.png)

Which is being resized to a much smaller string:

![image](https://user-images.githubusercontent.com/14224149/70868612-97ba4d00-1f82-11ea-996d-d20f61f13d93.png)

You will gain more for larger images of course ...

The readme page has been expanded with a "Node configuration" section, that explains that lower bandwith will result in higher cpu usage (due to resizing):

![image](https://user-images.githubusercontent.com/14224149/70868882-48c1e700-1f85-11ea-8f7c-570910e346b8.png)

The info panel also has been extended:

![image](https://user-images.githubusercontent.com/14224149/70868894-7e66d000-1f85-11ea-8cbb-97ab82cc959d.png)

BTW I have used [Jimp](https://www.npmjs.com/package/jimp) to resize the images.  Perhaps that might be a bit overkill, but I have tried some other image resizing npm libraries: those were based on  C++ libraries (like e.g. [sharp](https://www.npmjs.com/package/sharp)), which caused a lot of compilation troubles on my Raspberry.  So now we have a full Javascript solution.  Perhaps not as fast as C++, but then at least nobody has troubles installing it ...

Hope you like this change!
Bart