### PR TITLE
Activation button

### DIFF
--- a/image/image.html
+++ b/image/image.html
@@ -12,6 +12,9 @@
       },
       thumbnail: {
         value: false
+      },
+      active: {
+        value: true
       }
     },
     inputs: 1,
@@ -24,6 +27,52 @@
     },
     labelStyle: function() {
       return this.name?"node_label_italic":"";
+    },
+    button: {
+      toggle: "active",
+      onclick: function() {
+        const label = this.name || "image preview";
+        var node = this;
+        $.ajax({
+          url: `image-output/${this.id}/${this.active ? 'enable' : 'disable'}`,
+          type: "POST",
+          success: function(resp, textStatus, xhr) {
+            const historyEvent = {
+              t:'edit',
+              node:node,
+              changes:{
+                active: !node.active
+              },
+              dirty:node.dirty,
+              changed:node.changed
+            };
+            node.changed = true;
+            node.dirty = true;
+            RED.nodes.dirty(true);
+            RED.history.push(historyEvent);
+            RED.view.redraw();
+            if (xhr.status == 200) {
+              RED.notify("Successfully " + resp + ": " + label, "success");
+            }
+          },
+          error: function(jqXHR,textStatus,errorThrown) {
+            var message;
+            
+            switch (jqXHR.status) {
+              case 404:
+                message = "node not deployed";
+                break;
+              case 0:
+                message = "no response from server";
+                break;
+              default:
+                message = `unexpected error (${textStatus}) ${errorThrown}`;
+            }
+            
+            RED.notify(`<strong>Error</strong>: ${message}`, "error");
+          }
+        });
+      }
     },
     oneditprepare: function() {
       // Set a default width of 160 for existing nodes that don't have that field yet.


### PR DESCRIPTION
Hi @rikukissa , @dceejay ,

I have added an activation/deactivation button.  When clicked, the images will be ignored (on the server-side) and not send - via the websocket channel - to the client side.  This way you can add as many image-output nodes to your flow, without having to be worried the websocket channel is going to be overloaded.

P.S. This is a bit more convenient compared to "disabling" the node via the Node-RED disable button, since you can use the activation button "live"...

Here is a small demo (that automatically generates images in the cloud):

![image_output_button](https://user-images.githubusercontent.com/14224149/71211926-82119400-22b0-11ea-904e-043f9c4481a0.gif)

```
[{"id":"46ffc819.b736f8","type":"http request","z":"30fb1577.8f556a","name":"","method":"GET","ret":"bin","paytoqs":false,"url":"https://dummyimage.com/200x150/000/fff&text={{{payload}}}","tls":"","persist":false,"proxy":"","authType":"","x":610,"y":640,"wires":[["27a53fad.5c768"]]},{"id":"25d928c1.708098","type":"inject","z":"30fb1577.8f556a","name":"Generate next image","topic":"","payload":"","payloadType":"date","repeat":"","crontab":"","once":false,"onceDelay":0.1,"x":200,"y":640,"wires":[["878f8ec1.effe4"]]},{"id":"878f8ec1.effe4","type":"function","z":"30fb1577.8f556a","name":"image counter","func":"var count = flow.get(\"count\")||0;\n\ncount++;\n\nnode.status({fill:\"blue\",shape:\"ring\",text:\"Image \" + count});\n\n// Save the new value back to context so it will be available next time\nflow.set('count',count);\n\n// Update the message payload and return - no need to create a new msg\nmsg.payload = \"Image \" + count;\nreturn msg;","outputs":1,"noerr":0,"x":420,"y":640,"wires":[["46ffc819.b736f8"]]},{"id":"27a53fad.5c768","type":"base64","z":"30fb1577.8f556a","name":"","action":"str","property":"payload","x":780,"y":640,"wires":[["d603e881.2fa1c8"]]},{"id":"d603e881.2fa1c8","type":"image","z":"30fb1577.8f556a","name":"","width":160,"thumbnail":false,"x":960,"y":640,"wires":[]}]
```

## I have one open issue, but don't know how to solve it ;(
To have no impact on **existing** flows, I would like to have the existing nodes to be **activated by default**.  However these existing nodes don't have a ```node.active``` field yet, until the user opens the config screen.  As a result:
+ At server side I consider the node being active, when node.active is undefined.  This seems to be working fine (i.e. the node is activated):
   
   ![image](https://user-images.githubusercontent.com/14224149/71212114-f77d6480-22b0-11ea-9adb-1676fa4bbe59.png)

+ But on the client side the existing node is deactivated by default:

   ![image](https://user-images.githubusercontent.com/14224149/71212215-2abff380-22b1-11ea-891e-186bb8ef66f4.png)

   That is not what I want, since the node has a visual appearance of being deactivated (**while** it is activated on the server).  But don't know how to disable the button by default, based on a ```node.active``` value that is **undefined** at that moment...